### PR TITLE
feat: add exports field to package.json for module compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,13 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "rollup -c",
     "prepare": "npm run build"


### PR DESCRIPTION
This pull request updates the `package.json` to improve how the package is exported for consumers. The main change is the addition of an `exports` field, which clearly defines entry points for import, require, and types, ensuring better compatibility with modern JavaScript tooling and TypeScript.

**Package export improvements:**

* Added an `exports` field to `package.json` to specify explicit entry points for ESM (`import`), CommonJS (`require`), and TypeScript types (`types`).