### PR TITLE
Fix/umd export naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ import { maskNumber, countries } from 'mask-any-number';
 
 // Germany 🇩🇪
 maskNumber('493012345678', countries.find(country => country.iso2 === 'DE').masks); 
-// "+49 30 1234 5678"
+// "30 1234 5678"
 
 // Brazil 🇧🇷
 maskNumber('5511998765432', countries.find(country => country.iso2 === 'BR').masks); 
-// "+55 11 99876 5432"
+// "11 99876 5432"
 
 // US 🇺🇸
 maskNumber('1234567890', countries.find(country => country.iso2 === 'US').masks); 
@@ -66,11 +66,11 @@ maskNumber('861012345678', ['+86 00 0000 0000']); // "+86 10 1234 5678"
 Return: `string` — formatted number according to the first mask that fits.
 
 # 🔁 Visual Summary
-| Type        | Input          | Mask                | Output          |
-|------------|----------------|-------------------|----------------|
-| US Phone   | 1234567890     | (000) 000-0000    | (123) 456-7890 |
-| EU Phone   | 493012345678   | +49 00 0000 0000  | +49 30 1234 5678 |
-| CN Phone   | 861012345678   | +86 00 0000 0000  | +86 10 1234 5678 |
+| Type        | Input           | Mask                | Output          |
+|-------------|-----------------|---------------------|----------------|
+| US Phone    | 1234567890      | (000) 000-0000      | (123) 456-7890 |
+| EU Phone    | 493012345678    | 00 0000 0000        | 30 1234 5678 |
+| CN Phone    | 861012345678    | 00 0000 0000        | 10 1234 5678 |
 
 # 🧪 Testing with Mock Data
 ```javascript

--- a/docs/index.html
+++ b/docs/index.html
@@ -109,7 +109,7 @@ maskNumber('1234567890', countries.find(country => country.iso2 === 'US').masks)
         <p class="text-sm">Open source available on <a href="https://github.com/gabrielrfmendes/mask-any-number"
                 target="_blank" class="text-blue-400 hover:underline">GitHub</a></p>
     </footer>
-    <script src="../dist/index.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mask-any-number/dist/index.umd.min.js"></script>
     <script src="script.js"></script>
 </body>
 

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,3 +1,5 @@
+const { maskNumber, countries } = MaskAnyNumber;
+
 const input = document.getElementById('phoneNumberInput');
 const select = document.getElementById('maskSelect');
 
@@ -9,11 +11,10 @@ countries.forEach(country => {
 });
 
 function handleChange() {
-    const masked = maskNumber(input.value, countries.find(c => c.iso2 === select.value)?.masks || []);
-
+    const country = countries.find(c => c.iso2 === select.value);
+    const masked = maskNumber(input.value, country?.masks || []);
     input.value = masked;
 }
-
 
 input.addEventListener('input', handleChange);
 select.addEventListener('change', handleChange);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mask-any-number",
-  "version": "1.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mask-any-number",
-      "version": "1.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mask-any-number",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Apply flexible numeric masks to any string. Perfect for phone numbers, documents, and custom input formatting.",
   "main": "dist/index.cjs.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "unpkg": "dist/index.umd.min.js",
+  "jsdelivr": "dist/index.umd.min.js",
   "scripts": {
     "build": "rollup -c",
     "prepare": "npm run build"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import typescript from "@rollup/plugin-typescript";
 import terser from "@rollup/plugin-terser";
-import json from '@rollup/plugin-json';
+import json from "@rollup/plugin-json";
 
 export default {
     input: "src/index.ts",
@@ -11,7 +11,7 @@ export default {
             file: "dist/index.cjs.js",
             format: "cjs",
             sourcemap: true,
-            exports: 'named'
+            exports: "named"
         },
         {
             file: "dist/index.js",
@@ -21,13 +21,13 @@ export default {
         {
             file: "dist/index.umd.js",
             format: "umd",
-            name: "maskNumber",
+            name: "MaskAnyNumber",
             sourcemap: true
         },
         {
             file: "dist/index.umd.min.js",
             format: "umd",
-            name: "maskNumber",
+            name: "MaskAnyNumber",
             plugins: [terser()],
             sourcemap: true
         }


### PR DESCRIPTION
This pull request includes several improvements to the documentation, build configuration, and usage examples for the `mask-any-number` library. The changes focus on making the library easier to use via CDN, clarifying usage in the documentation, and ensuring consistency in naming and output formatting.

**Documentation and Example Updates:**

* Updated example outputs in `README.md` and the visual summary table to remove country codes from the masked output for Germany, Brazil, EU, and China, making the examples consistent and clearer. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L70-R73)
* Changed the CDN script source in `docs/index.html` to use jsdelivr, allowing users to load the library directly from a CDN.
* Updated `docs/script.js` to use the `MaskAnyNumber` global variable from the UMD build, and improved the masking logic for better clarity and maintainability. [[1]](diffhunk://#diff-61868e0403bf1fff565547e93490bb360a612cd436b957474cd306b13ab997c7R1-R2) [[2]](diffhunk://#diff-61868e0403bf1fff565547e93490bb360a612cd436b957474cd306b13ab997c7L12-L17)

**Build and Distribution Configuration:**

* Added `unpkg` and `jsdelivr` fields to `package.json` to facilitate CDN delivery of the UMD build.
* Updated the UMD build name in `rollup.config.js` from `maskNumber` to `MaskAnyNumber` for consistency with the global variable used in examples. Also made minor formatting improvements. [[1]](diffhunk://#diff-6814bf77564b4f1c92f5861e184e28fe217c080a047fefa8b73a728f755ec45cL5-R5) [[2]](diffhunk://#diff-6814bf77564b4f1c92f5861e184e28fe217c080a047fefa8b73a728f755ec45cL14-R14) [[3]](diffhunk://#diff-6814bf77564b4f1c92f5861e184e28fe217c080a047fefa8b73a728f755ec45cL24-R30)

**Version Update:**

* Bumped the package version to `2.3.1` in `package.json` to reflect these changes.