### PR TITLE
Fix/umd export naming

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -1,4 +1,4 @@
-const { maskNumber, countries } = MaskAnyNumber;
+const { maskNumber, countries } = window.maskNumber;
 
 const input = document.getElementById('phoneNumberInput');
 const select = document.getElementById('maskSelect');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mask-any-number",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mask-any-number",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mask-any-number",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mask-any-number",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mask-any-number",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Apply flexible numeric masks to any string. Perfect for phone numbers, documents, and custom input formatting.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mask-any-number",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Apply flexible numeric masks to any string. Perfect for phone numbers, documents, and custom input formatting.",
   "main": "dist/index.cjs.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "2.3.2",
   "description": "Apply flexible numeric masks to any string. Perfect for phone numbers, documents, and custom input formatting.",
   "main": "dist/index.cjs.js",
-  "type": "module",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs.js",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./dist/index.umd.js": "./dist/index.umd.js",
+    "./dist/index.umd.min.js": "./dist/index.umd.min.js"
   },
   "unpkg": "dist/index.umd.min.js",
   "jsdelivr": "dist/index.umd.min.js",


### PR DESCRIPTION
This pull request makes updates to the packaging and usage of the `mask-any-number` library, primarily to improve compatibility and distribution. The most significant changes involve how the library is referenced in browser environments and how its build artifacts are exposed in `package.json`.

Packaging and distribution improvements:

* Updated the import in `docs/script.js` to reference `window.maskNumber` instead of `MaskAnyNumber`, ensuring correct usage in browser environments.
* Added UMD and minified UMD build files (`dist/index.umd.js` and `dist/index.umd.min.js`) to the `exports` field in `package.json` for better CDN and browser support.
* Bumped the package version from `2.3.1` to `2.3.3` in `package.json` to reflect these changes.
* Removed the `"type": "module"` field from `package.json`, which may help with compatibility in certain environments.